### PR TITLE
Add optional "preview" decrypt before "full" decrypt

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,10 @@ To install it on your system, use the command:
                as successful when the data contains mostly printable ASCII
                characters (at least 90%).
 
+  -p <n>       Preview and check the first N decrypted bytes for the magic string.
+               If the magic string is present, try decrypting the rest of the data.
+                 default: 1024
+
   -m <length>  Maximum password length (beginning and end included).
                  default: 8
 

--- a/src/bruteforce-salted-openssl.c
+++ b/src/bruteforce-salted-openssl.c
@@ -802,7 +802,7 @@ void usage(char *progname)
   fprintf(stderr, "               characters (at least 90%%).\n\n");
   fprintf(stderr, "  -p <n>       Preview and check the first N decrypted bytes for the magic string.\n");
   fprintf(stderr, "               If the magic string is present, try decrypting the rest of the data.\n");
-  fprintf(stderr, "                 default: 1024\n");
+  fprintf(stderr, "                 default: 1024\n\n");
   fprintf(stderr, "  -m <length>  Maximum password length (beginning and end included).\n");
   fprintf(stderr, "                 default: 8\n\n");
   fprintf(stderr, "  -N           Ignore decryption errors (similar to openssl -nopad).\n\n");


### PR DESCRIPTION
This pull request adds an optional "preview" decrypt before attempting to decrypt the entire remaining data.  

For example, let's say you're looking for the magic string "abcd".  You decrypt the first 4 bytes and they're "wxyz".  At this point, you know you don't need to decrypt the rest of the file.  However, if the decrypted data does start with "abcd", decrypt the rest of the file to verify PKCS padding, validity, etc.  
In the case of character frequency analysis, the first N (default 1024) bytes are decrypted and checked.  If they meet the `valid_data` check, then decrypt and check the rest of the file.  This can potentially result in false negatives, hence why the value can be tuned.

As for performance comparison, I was attempting to brute force a 32MB encrypted file.  Before the tweak I was getting 250 words/sec regardless of magic string or not.  After the tweak I am getting over 200,000 words/sec without a magic string and almost 500,000 words/sec with one.