### PR TITLE
Solves false positive case where decryption fails but password candidate is accepted

### DIFF
--- a/src/bruteforce-salted-openssl.c
+++ b/src/bruteforce-salted-openssl.c
@@ -499,10 +499,12 @@ void * decryption_func(void *arg)
 
     /* Don't bother checking the rest if the first preview part didn't match. */
     if(preview_found) {
-      EVP_DecryptUpdate(ctx, out + total_out_len, &cur_out_len, data + preview_len, data_len - preview_len);
-      total_out_len += cur_out_len;
-      ret = EVP_DecryptFinal(ctx, out + total_out_len, &cur_out_len);
-      total_out_len += cur_out_len;
+      ret = EVP_DecryptUpdate(ctx, out + total_out_len, &cur_out_len, data + preview_len, data_len - preview_len);
+      if ( ret==1 ) {
+        total_out_len += cur_out_len;
+        ret = EVP_DecryptFinal(ctx, out + total_out_len, &cur_out_len);
+        total_out_len += cur_out_len;
+      } 
     }
 
     if(no_error || (ret == 1))
@@ -1301,5 +1303,6 @@ int main(int argc, char **argv)
   free(data);
   EVP_cleanup();
 
-  exit(EXIT_SUCCESS);
+  if ( found_password==0 ) return 1;
+  return 0;
 }


### PR DESCRIPTION
An edge case happens when false positive passwords are accepted as candidates erroneously. 

Password candidate is accepted as a solution because the code is ignoring the result of the first EVP_DecryptUpdate

The fix is to check the result of both calls and fail if any result is a failure.

Binary is also made to return 0 as success (in case one password was found) and 1 if no password was found. This is to help shell scripts calling this binary to identify when a solution was found.

